### PR TITLE
Fix incorrect record creation with predefined rowData

### DIFF
--- a/FSharp.Data.FlatFileMeta/FlatFileMeta.fs
+++ b/FSharp.Data.FlatFileMeta/FlatFileMeta.fs
@@ -264,7 +264,9 @@ type FlatRow(rowData:string) =
             columnLength <- totalLength
             columnKeys <- orderedKeys
             rawData <- match rowInput with
-                        | Some (row) -> row |> Array.ofSeq |> Array.map string
+                        | Some (row) -> 
+                            row.PadRight totalLength
+                            |> Array.ofSeq |> Array.map string
                         | None -> Array.init totalLength (fun _ -> " ")
             columnMap <- mapMeta
             this.PostSetup()


### PR DESCRIPTION
When a record is created with a string for `rowData`, it leads to `IndexOutOfRangeException` downstream when the string is not of equal length to the expected fixed size string. Adding padding solves this (though the string can still be too long as well).

This solves https://github.com/ekonbenefits/NachaSharp/issues/6.